### PR TITLE
Avoid use of bool as a variable name for C23

### DIFF
--- a/src/fplsa4.c
+++ b/src/fplsa4.c
@@ -7010,21 +7010,21 @@ void ReadAndProcessStringsFromFile(void (*proc_func)(char *str), FILE *inf,
 int ReadBooleanFromFile(FILE *file)
 {
   short c;
-  int bool;
+  int boolvar;
   c = fgetc(file);
   switch(c)
   {
     case 'Y': case 'y':
-    bool = YES;
+    boolvar = YES;
     break;
     case 'N': case 'n':
-    bool = NO;
+    boolvar = NO;
     break;
   }
   while(!isspace(c = fgetc(file)) && c != EOF)
     ;
   ungetc(c, file);
-  return bool;
+  return boolvar;
 }
 /*=ReadCaseFromFile=====================================
 */


### PR DESCRIPTION
The upcoming release of GCC 15 changes the default C standard to C23.  In C23, `bool` is a keyword, so cannot be used as a variable name.