### PR TITLE
Avoid use of reserved C99 keyword "bool" as a variable name

### DIFF
--- a/src/fplsa4.c
+++ b/src/fplsa4.c
@@ -7010,21 +7010,21 @@ void ReadAndProcessStringsFromFile(void (*proc_func)(char *str), FILE *inf,
 int ReadBooleanFromFile(FILE *file)
 {
   short c;
-  int bool;
+  int b = NO;
   c = fgetc(file);
   switch(c)
   {
     case 'Y': case 'y':
-    bool = YES;
+    b = YES;
     break;
     case 'N': case 'n':
-    bool = NO;
+    b = NO;
     break;
   }
   while(!isspace(c = fgetc(file)) && c != EOF)
     ;
   ungetc(c, file);
-  return bool;
+  return b;
 }
 /*=ReadCaseFromFile=====================================
 */


### PR DESCRIPTION
gcc15 comes with -std=c23 by default. The C99 bool keyword is still in effect. C23 has only deprecated it, not removed it.

gcc-15 output:

```
src/fplsa4.c: In function ‘ReadBooleanFromFile’:
src/fplsa4.c:7013:7: error: ‘bool’ cannot be used here
 7013 |   int bool;
src/fplsa4.c:7013:7: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
src/fplsa4.c:7013:3: warning: useless type name in empty declaration
 7013 |   int bool;
```

gcc-14 output:

```
src/fplsa4.c: In function ‘ReadBooleanFromFile’:
src/fplsa4.c:7027:10: warning: ‘bool’ may be used uninitialized [-Wmaybe-uninitialized]
 7027 |   return bool;
```
